### PR TITLE
ci(guard): rely on injected core

### DIFF
--- a/.github/workflows/guard-direct-push.yml
+++ b/.github/workflows/guard-direct-push.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const sha = context.payload.after;
@@ -56,7 +55,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const branch = context.ref.replace('refs/heads/', '');


### PR DESCRIPTION
Stop requiring @actions/core inside github-script since core is already injected, avoiding redeclaration errors.